### PR TITLE
CentOS 7 Support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,7 +7,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-  - name: centos-6.4
+  - name: ubuntu-14.04
+  - name: centos-6.6
+  - name: centos-7.0
 
 suites:
   - name: default

--- a/files/default/yum_opsmatic_public.repo
+++ b/files/default/yum_opsmatic_public.repo
@@ -1,6 +1,6 @@
 [opsmatic_public]
 name=opsmatic_public
-baseurl=https://packagecloud.io/opsmatic/public/el/6/$basearch
+baseurl=https://packagecloud.io/opsmatic/public/el/$releasever/$basearch
 enabled=1
 gpgcheck=1
 sslverify=1

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -8,11 +8,11 @@ if node['opsmatic']['integration_token'].nil? || node['opsmatic']['integration_t
 end
 
 # CentOS 7 detection
-if node[:platform_family] == 'rhel' && node[:platform_version] =~ /^7/ 
-    centos7 = true
-    opsmatic_package = 'opsmatic-agent-systemd'
+if node['platform_family'] == 'rhel' && node['platform_version'] =~ /^7/
+  centos7 = true
+  opsmatic_package = 'opsmatic-agent-systemd'
 else
-    opsmatic_package = 'opsmatic-agent'
+  opsmatic_package = 'opsmatic-agent'
 end
 
 if node['opsmatic']['public_repo']
@@ -27,7 +27,6 @@ if node['opsmatic']['public_repo']
     return
   end
 end
-
 
 # install the opsmatic agent
 package opsmatic_package do
@@ -57,9 +56,9 @@ include_recipe 'opsmatic::file-integrity-monitoring'
 # configure the service
 service 'opsmatic-agent' do
   if centos7
-      provider Chef::Provider::Service::Systemd
+    provider Chef::Provider::Service::Systemd
   else
-      provider Chef::Provider::Service::Upstart
+    provider Chef::Provider::Service::Upstart
   end
   action [:enable, :start]
 end

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -7,6 +7,14 @@ if node['opsmatic']['integration_token'].nil? || node['opsmatic']['integration_t
   raise 'You need to configure your Opsmatic integration_token attribute to install the Opsmatic Agent'
 end
 
+# CentOS 7 detection
+if node[:platform_family] == 'rhel' && node[:platform_version] =~ /^7/ 
+    centos7 = true
+    opsmatic_package = 'opsmatic-agent-systemd'
+else
+    opsmatic_package = 'opsmatic-agent'
+end
+
 if node['opsmatic']['public_repo']
   # wire up the appropriate repositories
   case node['platform_family']
@@ -20,8 +28,9 @@ if node['opsmatic']['public_repo']
   end
 end
 
+
 # install the opsmatic agent
-package 'opsmatic-agent' do
+package opsmatic_package do
   action node['opsmatic']['agent_action']
   version node['opsmatic']['agent_version']
 end
@@ -46,6 +55,10 @@ include_recipe 'opsmatic::file-integrity-monitoring'
 
 # configure the service
 service 'opsmatic-agent' do
-  provider Chef::Provider::Service::Upstart
+  if centos7
+      provider Chef::Provider::Service::Systemd
+  else
+      provider Chef::Provider::Service::Upstart
+  end
   action [:enable, :start]
 end

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -49,6 +49,7 @@ template '/etc/opsmatic-agent.conf' do
   owner 'root'
   group 'root'
   mode '00644'
+  notifies :restart, 'service[opsmatic-agent]', :delayed
 end
 
 include_recipe 'opsmatic::file-integrity-monitoring'

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -5,4 +5,5 @@ template '/etc/default/opsmatic-global' do
   owner 'root'
   group 'root'
   mode '00644'
+  notifies :restart, 'service[opsmatic-agent]', :delayed
 end


### PR DESCRIPTION
I was trying to use this cookbook to install the opsmatic agent on CentOS 7, however it would still install the upstart package and try to use the upstart service provider. In addition, it was hard-coded to use the CentOS 6 opsmatic repository. 

I have made the following changes:
* Use the yum $releasever variable in the .repo file to support either CentOS 6 or CentOS 7
* Check for CentOS 7 in the agent recipe and install the opsmatic-agent-systemd package if found
* Check for CentOS 7 in the agent recipe and use the Chef systemd service provider if found
* Automatically restart the agent if a config file was updated by chef

Let me know if this looks good or if there is another approach you prefer.